### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/populate/case_studies.R
+++ b/populate/case_studies.R
@@ -14,7 +14,7 @@ library(stringi)
 orcid <- data.frame(simon = "orcid.org/0000-0002-2700-4605",
                     jessica = "orcid.org/0000-0003-4048-177X")
 
-neotoma <- "http://doi.org/10.17616/R3PD38"
+neotoma <- "https://doi.org/10.17616/R3PD38"
 
 # Simon finds a core:
 
@@ -72,7 +72,7 @@ target <- blois_sets
 body <- list(body = list(type='TextualBody',
              value ='Age models rebuilt with new biostratigraphic markers.'),
              body = list(type = 'ScholarlyArticle',
-                         value='http://dx.doi.org/10.1016/j.quascirev.2011.04.017'))
+                         value='https://doi.org/10.1016/j.quascirev.2011.04.017'))
 
 link_record(con = con, creator = creator, body = body, target = target)
 

--- a/populate/cql/add_note.cql
+++ b/populate/cql/add_note.cql
@@ -1,5 +1,5 @@
 CREATE (ann:annotation {created: timestamp()})
-WITH [{type:"TextualBody",value:"Age models rebuilt with new biostratigraphic markers."},{type:"ScholarlyArticle",value:"http://dx.doi.org/10.1016/j.quascirev.2011.04.017"}] as prop, ann
+WITH [{type:"TextualBody",value:"Age models rebuilt with new biostratigraphic markers."},{type:"ScholarlyArticle",value:"https://doi.org/10.1016/j.quascirev.2011.04.017"}] as prop, ann
 UNWIND prop AS bodyprop
 MERGE (bod:body {type:bodyprop.type, value:bodyprop.value})
 MERGE (ann)<-[annotates:annotates]-(bod)


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

Here, I'd like to suggest to update all static DOI links accordingly.

Cheers!